### PR TITLE
[Doc Engine] Remove referências à arquivos de documentação markdown

### DIFF
--- a/stackspot_store/schemas/action/v1/container-schema.json
+++ b/stackspot_store/schemas/action/v1/container-schema.json
@@ -25,18 +25,6 @@
                         "container"
                     ]
                 },
-                "about": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "implementation": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "requirements": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "release-notes": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
                 "repository": { 
                     "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/repository" 
                 },

--- a/stackspot_store/schemas/action/v1/python-schema.json
+++ b/stackspot_store/schemas/action/v1/python-schema.json
@@ -25,18 +25,6 @@
                         "python"
                     ]
                 },
-                "about": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "implementation": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "requirements": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "release-notes": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
                 "repository": { 
                     "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/repository" 
                 },

--- a/stackspot_store/schemas/action/v1/shell-schema.json
+++ b/stackspot_store/schemas/action/v1/shell-schema.json
@@ -25,18 +25,6 @@
                         "shell"
                     ]
                 },
-                "about": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "implementation": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "requirements": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "release-notes": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
                 "repository": { 
                     "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/repository" 
                 },

--- a/stackspot_store/schemas/action/v1/web-schema.json
+++ b/stackspot_store/schemas/action/v1/web-schema.json
@@ -25,18 +25,6 @@
                         "webservice"
                     ]
                 },
-                "about": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "implementation": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "requirements": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
-                "release-notes": { 
-                    "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/markdown" 
-                },
                 "repository": { 
                     "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/action/v1/_definitions.json#/definitions/repository" 
                 },

--- a/stackspot_store/schemas/plugin/v1/app-schema.json
+++ b/stackspot_store/schemas/plugin/v1/app-schema.json
@@ -16,10 +16,6 @@
         "type": "object", 
         "properties": {
           "type": { "type": "string", "enum": ["app"] },
-          "about": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/markdown" },
-          "implementation": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/markdown" },
-          "requirements": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/markdown" },
-          "release-notes": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/markdown" },
           "inputs": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/inputs" },
           "inputs-envs": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/inputs" },
           "compatibility": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/compatibility" },

--- a/stackspot_store/schemas/plugin/v1/infra-schema.json
+++ b/stackspot_store/schemas/plugin/v1/infra-schema.json
@@ -16,10 +16,6 @@
         "type": "object", 
         "properties": {
           "type": { "type": "string", "enum": ["infra"] },
-          "about": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/markdown" },
-          "implementation": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/markdown" },
-          "requirements": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/markdown" },
-          "release-notes": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/markdown" },
           "inputs": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/inputs" },
           "inputs-envs": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/inputs" },
           "compatibility": { "$ref": "https://raw.githubusercontent.com/stack-spot/schemastore-stackspot/main/stackspot_store/schemas/plugin/v1/_definitions.json#/definitions/compatibility" },

--- a/stackspot_store/schemas/plugin/v1/plugin_app.yaml
+++ b/stackspot_store/schemas/plugin/v1/plugin_app.yaml
@@ -10,10 +10,6 @@ spec:
   type: app
   compatibility:
     - python
-  about: docs/about.md
-  implementation: docs/implementation.md
-  release-notes: docs/release-notes-0.0.1.md
-  requirements: docs/requirements.md
   repository: https://github.com/stack-spot/test-plugin.git
   technologies: # Ref: https://docs.stackspot.com/docs/create-stacks/yaml-files/yaml/#technologies
     - Api

--- a/stackspot_store/templates/plugin/v1/app/templates/plugin.yaml
+++ b/stackspot_store/templates/plugin/v1/app/templates/plugin.yaml
@@ -10,10 +10,6 @@ spec:
   type: app
   compatibility:
     - python
-  about: docs/about.md
-  implementation: docs/implementation.md
-  release-notes: docs/release-notes-{{version}}.md
-  requirements: docs/requirements.md
   {% if add_repository %}
   repository: {{repository}}
   {% endif %}

--- a/stackspot_store/templates/plugin/v1/infra/templates/plugin.yaml
+++ b/stackspot_store/templates/plugin/v1/infra/templates/plugin.yaml
@@ -10,10 +10,6 @@ spec:
   type: infra
   compatibility:
     - python
-  about: docs/about.md
-  implementation: docs/implementation.md
-  release-notes: docs/release-notes-{{version}}.md
-  requirements: docs/requirements.md
   {% if add_repository %}
   repository: {{repository}}
   {% endif %}


### PR DESCRIPTION
Com a implementação da Doc Engine, não utilizaremos mais os campos abaixo que apontavam para arquivos markdown nos yamls:

- requirements
- about
- usage
- implementation
- release-notes

Dessa forma as validações não devem mais levá-los em consideração.